### PR TITLE
docs: fix version typo

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## v1.7.0
+## 1.7.0
 
 **Release Date:** 18.11.2020
 

--- a/docs/ru/changelog.md
+++ b/docs/ru/changelog.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## v1.7.0
+## 1.7.0
 
 **Release Date:** 18.11.2020
 


### PR DESCRIPTION
удалил `v`