### PR TITLE
[SDK-405] Методы isSupported, notSupportedReason

### DIFF
--- a/app/src/main/java/ru/dublgis/dgismobile/sdktestapp/LogTag.kt
+++ b/app/src/main/java/ru/dublgis/dgismobile/sdktestapp/LogTag.kt
@@ -1,0 +1,3 @@
+package ru.dublgis.dgismobile.sdktestapp
+
+val TAG = "mapgl_app"

--- a/app/src/main/java/ru/dublgis/dgismobile/sdktestapp/MapActivity.kt
+++ b/app/src/main/java/ru/dublgis/dgismobile/sdktestapp/MapActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -81,12 +82,14 @@ abstract class MapActivity(val options: Options = Options()) : AppCompatActivity
         return true
     }
 
-    private fun onDGisMapReady(controller: Map?) {
-        map = controller
-        map?.enableUserLocation(UserLocationOptions(isVisible = true))
-        map?.userLocation?.observe(this, Observer {
-        })
+    private fun onDGisMapReady(map: Map) {
+        this.map = map
+        map.enableUserLocation(UserLocationOptions(isVisible = true))
+        map.userLocation.observe(this, Observer {})
 
+        if (!map.isSupported()) {
+            Log.e(TAG, "MapGL SDK is not supported: ${map.notSupportedReason()}")
+        }
         onDGisMapReady()
     }
 

--- a/mapsdk/src/main/assets/mapgl/index.html
+++ b/mapsdk/src/main/assets/mapgl/index.html
@@ -46,6 +46,20 @@ window.initMapGL = (
         maxBounds,
         padding) => {
 
+    const emit = (name, args) => {
+        if (bridge && bridge.onEvent) {
+            const payload = args
+                ? args
+                : ""
+            bridge.onEvent(name, payload);
+
+        } else {
+            console.error('bridge unavailable or onEvent handler does not exist');
+        }
+    };
+
+    try {
+
     const markers = new Map();
     const clusterers = new Map();
     const polylines = new Map();
@@ -99,18 +113,6 @@ window.initMapGL = (
     	// TODO: использовать опцию создания карты, когда такая появится
     	map.setStyleZoom(styleZoom, {animate: false});
     }
-
-    const emit = (name, args) => {
-        if (bridge && bridge.onEvent) {
-            const payload = args 
-                ? args
-                : ""
-            bridge.onEvent(name, payload);
-
-        } else {
-            console.error('bridge unavailable or onEvent handler does not exist');
-        }
-    };
 
     const subscribe = (name, handler) => {
         map.on(name, (ev) => {
@@ -411,6 +413,20 @@ window.initMapGL = (
     emit('initBounds', `${bounds.northEast[0]};${bounds.northEast[1]} ${bounds.southWest[0]};${bounds.southWest[1]}`);
     emit('zoomChanged', map.getZoom());
     emit('styleZoomChanged', map.getStyleZoom());
+
+    const support = {
+        notSupportedReason: mapgl.notSupportedReason({failIfMajorPerformanceCaveat: false}),
+        notSupportedWithGoodPerformanceReason: mapgl.notSupportedReason({failIfMajorPerformanceCaveat: true})
+    }
+    emit('supportChanged', JSON.stringify(support));
+
+    } catch(e) {
+        const support = {
+            notSupportedReason: e.toString(),
+            notSupportedWithGoodPerformanceReason: e.toString()
+        }
+        emit('supportChanged', JSON.stringify(support));
+    }
     emit('initialized');
 };
 

--- a/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/Map.kt
+++ b/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/Map.kt
@@ -123,4 +123,15 @@ interface Map {
      * @param options FitBounds options
      */
     fun fitBounds(bounds: LonLatBounds, options: FitBoundsOptions? = null)
+
+    /**
+     * Tests whether the current browser supports MapGL.
+     * Use our raster map implementation https://api.2gis.ru/doc/maps/en/quickstart/ if not.
+     */
+    fun isSupported(options: MapSupportOptions? = null): Boolean
+
+    /**
+     * Tests whether the current browser supports MapGL and returns the reason if not
+     */
+    fun notSupportedReason(options: MapSupportOptions? = null): String?
 }

--- a/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/MapFragment.kt
+++ b/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/MapFragment.kt
@@ -142,7 +142,7 @@ class MapFragment : Fragment() {
 
     // ------------------------------------------------------
 
-    private fun onMapReady(map: Map?) {
+    private fun onMapReady(map: Map) {
         mapReadyCallback(map)
     }
 

--- a/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/MapSupport.kt
+++ b/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/MapSupport.kt
@@ -1,0 +1,17 @@
+package ru.dublgis.dgismobile.mapsdk
+
+import org.json.JSONObject
+
+internal class MapSupport(
+    val notSupportedReason: String?,
+    val notSupportedWithGoodPerformanceReason: String?)
+{
+    companion object {
+        fun fromJson(json: JSONObject): MapSupport {
+            return MapSupport(
+                notSupportedReason = json.opt("notSupportedReason") as String?,
+                notSupportedWithGoodPerformanceReason = json.opt("notSupportedWithGoodPerformanceReason") as String?
+            )
+        }
+    }
+}

--- a/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/MapSupportOptions.kt
+++ b/mapsdk/src/main/java/ru/dublgis/dgismobile/mapsdk/MapSupportOptions.kt
@@ -1,0 +1,12 @@
+package ru.dublgis.dgismobile.mapsdk
+
+/**
+ * Options for Map.isSupported method.
+ */
+data class MapSupportOptions(
+    /**
+     * Causes isSupported method to return false if the performance of MapGL would be
+     * dramatically worse than expected (i.e. a software renderer would be used)
+     */
+    val failIfMajorPerformanceCaveat: Boolean
+)


### PR DESCRIPTION
Многострадальный PR про isSupported.
Решил, что пусть этот метод будет у карты, карта создается всегда, если !map.isSupported то ее работоспособность не гарантируется, но пользователь может попытаться использовать (у меня на эмуляторе, например, говорит что не поддерживается, часть объектов не отображается, но в остальном работает).